### PR TITLE
時分秒が00:00:00とセットされていると翌月が条件に該当してしまう不具合修正

### DIFF
--- a/Service/SalesReportService.php
+++ b/Service/SalesReportService.php
@@ -162,7 +162,7 @@ class SalesReportService
             ->from('Eccube\Entity\Order', 'o')
             ->andWhere('o.del_flg = 0')
             ->andWhere('o.order_date >= :start')
-            ->andWhere('o.order_date <= :end')
+            ->andWhere('o.order_date < :end')
             ->andWhere('o.OrderStatus NOT IN (:excludes)')
             ->setParameter(':excludes', $excludes)
             ->setParameter(':start', $this->termStart)


### PR DESCRIPTION
期間別集計で「月別」で検索した時に翌月が該当してしまうため、該当しないように修正