### PR TITLE
集計処理の最適化を実施

### DIFF
--- a/Service/SalesReportService.php
+++ b/Service/SalesReportService.php
@@ -472,8 +472,6 @@ class SalesReportService
             $price[$date] = 0;
         }
 
-        $sql = 'Select o.customer_id From dtb_order o Where o.id = :order_id';
-        $stmt = $this->entityManager->getConnection()->prepare($sql);
         foreach ($data as $Order) {
             /* @var $Order \Eccube\Entity\Order */
             $orderDate = $Order
@@ -494,11 +492,7 @@ class SalesReportService
             $raw[$orderDate]['male'] += ($sexId == self::MALE);
             $raw[$orderDate]['female'] += ($sexId == self::FEMALE);
 
-            // Get customer id
-            $params['order_id'] = $Order->getId();
-            $stmt->execute($params);
-            $customerId = $stmt->fetch(\PDO::FETCH_COLUMN);
-            if ($customerId) {
+            if ($Order->getCustomer()) {
                 $raw[$orderDate]['member_male'] += ($sexId == self::MALE);
                 $raw[$orderDate]['member_female'] += ($sexId == self::FEMALE);
             } else {


### PR DESCRIPTION
### 対応内容

- 期間別集計および商品別集計の処理速度を改善
  - 期間別集計
    - 注文レコードのカスタマーIDを取得するのにSQL実行しているのをやめ、取得済の注文レコードにセットされてりうカスタマーIDを使用するようにしました。
  - 商品別集計
    - 注文レコード毎のループ内でOrderItemを取得するためにSQL実行するのをやめ、注文レコード取得時にJOINで取得するようにしました。

これによりデータ量が多いとき(数千件)で集計処理速度が5分の1程度に改善されます。