### PR TITLE
appveyorのビルドに失敗するのを修正

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ services:
 
 # Install scripts. (runs after repo cloning)
 install:
+  - ps: Set-Service wuauserv -StartupType Manual
   - cd  %PLUGIN_BASE_DIR%
   - git archive -o %PLUGIN_CODE%.tar.gz HEAD
 


### PR DESCRIPTION
appveyorでinstall時にwindows update serviceが有効だとビルドに失敗する事があるとの事なので、公式のレポートに従ってコマンドを追加しました。
ref: https://help.appveyor.com/discussions/problems/5616-not-able-to-build-due-to-problem-in-chocolateyinstallps1#comment_41949965