### PR TITLE
キャッシュの影響でセットアップが失敗するため削除

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
   - vendor
   - bin\.phpunit
-  - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 # Fix line endings in Windows. (runs before repo cloning)
 init:


### PR DESCRIPTION
メルマガプラグインと同様の修正を実施

https://github.com/EC-CUBE/mail-magazine-plugin/commit/1368d6a9928e837f18aa6941821331a0c2a4930f