### PR TITLE
エスケープ漏れ

### DIFF
--- a/Resource/template/admin/product.twig
+++ b/Resource/template/admin/product.twig
@@ -130,7 +130,7 @@ Copyright (C) EC-CUBE CO.,LTD. All Rights Reserved.
                                 <td class="align-middle text-center ps-3">{{ row.quantity|number_format }}</td>
                                 <td class="align-middle price-format text-end pe-3">
                                     {{ row.total|price }}
-                                    <span class="d-none">{{ row.total|raw }}</span>
+                                    <span class="d-none">{{ row.total }}</span>
                                 </td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
商品別集計で非表示の合計金額が raw で出力されているが、特にその必要が無く他の集計ではエスケープされているので、こちらもエスケープして出力する