### PR TITLE
[SalesReport42] リミットパス日を入力するとシステムエラー画面が表示されるくなる 不具合の修正 

### DIFF
--- a/Form/Type/SalesReportType.php
+++ b/Form/Type/SalesReportType.php
@@ -69,6 +69,12 @@ class SalesReportType extends AbstractType
                     'data-target' => '#'.$this->getBlockPrefix().'_term_start',
                     'data-toggle' => 'datetimepicker',
                 ],
+                'constraints' => [
+                    new Assert\Range([
+                        'min'=> '0003-01-01',
+                        'minMessage' => trans('sales_report.form_error.out_of_range'),
+                    ]),
+                ],
             ])
             ->add('term_end', DateType::class, [
                 'label' => 'sales_report.admin.label.term_end',
@@ -81,6 +87,12 @@ class SalesReportType extends AbstractType
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_term_end',
                     'data-toggle' => 'datetimepicker',
+                ],
+                'constraints' => [
+                    new Assert\Range([
+                        'min'=> '0003-01-01',
+                        'minMessage' => trans('sales_report.form_error.out_of_range'),
+                    ]),
                 ],
             ])
             ->add('unit', ChoiceType::class, [

--- a/Resource/locale/messages.ja.yml
+++ b/Resource/locale/messages.ja.yml
@@ -1,3 +1,4 @@
+sales_report.form_error.out_of_range: 不正な日付です。
 sales_report.admin.type.monthly.error: 集計月を選択してください。
 sales_report.admin.type.term_start.error: 集計期間を正しく選択してください。
 sales_report.admin.label.monthly_year: 年


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
[https://github.com/EC-CUBE/sales-report-plugin/issues/85](https://github.com/EC-CUBE/sales-report-plugin/issues/85) [SalesReport42] リミットパス日を入力するとシステムエラー画面が表示される

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
この問題を修正し、次のような機能テストを行いました。

![image](https://user-images.githubusercontent.com/105194449/192430527-bd5ee3cf-928a-48fa-84e3-46bcdda0f035.png)



## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか